### PR TITLE
Don’t crash on empty content type

### DIFF
--- a/src/c3nav/api/middleware.py
+++ b/src/c3nav/api/middleware.py
@@ -9,7 +9,7 @@ class JsonRequestBodyMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        is_json = request.META.get('CONTENT_TYPE').lower() == 'application/json'
+        is_json = request.META.get('CONTENT_TYPE', '').lower() == 'application/json'
         if is_json:
             try:
                 request.json_body = json.loads(request.body)


### PR DESCRIPTION
If the Content Type header is unset, the middleware will stacktrace with

```
ERROR 2019-03-01 14:44:02,442 django.request log Internal Server Error: /
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/c3nav/src/c3nav/api/middleware.py", line 12, in __call__
    is_json = request.META.get('CONTENT_TYPE').lower() == 'application/json'
AttributeError: 'NoneType' object has no attribute 'lower'
```

This commit fixes that.