### PR TITLE
Fix slug validation

### DIFF
--- a/src/c3nav/mapdata/models/locations.py
+++ b/src/c3nav/mapdata/models/locations.py
@@ -49,7 +49,7 @@ class LocationSlugManager(models.Manager):
 
 
 validate_slug = RegexValidator(
-    r'^[a-z0-9]+(--?[a-z0-9]+)*\Z',
+    r'^[a-z0-9]+(-?[a-z0-9]+)*\Z',
     # Translators: "letters" means latin letters: a-z and A-Z.
     _('Enter a valid location slug consisting of lowercase letters, numbers or hyphens, '
       'not starting or ending with hyphens or containing consecutive hyphens.'),


### PR DESCRIPTION
The current code allow double hyphens, contrary to what the error in the line below says.