### PR TITLE
fix translations display for docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt_$TARGETARCH --mount=type=tmp
     # renovate: srcname=librsvg
     gir1.2-rsvg-2.0=2.54.5+dfsg-1ubuntu2.1 \
     libgirepository-1.0-1=1.76.1-1 \
+    gettext \
     tzdata=2023d-0ubuntu0.23.04 \
     ca-certificates=20230311ubuntu0.23.04.1 \
     zstd=1.5.4+dfsg2-4
@@ -93,7 +94,8 @@ ENV C3NAV_DEBUG="" \
 USER c3nav
 WORKDIR /app
 
-RUN /app/env/bin/python manage.py collectstatic -l --no-input && \
+RUN /app/env/bin/python manage.py compilemessages && \
+    /app/env/bin/python manage.py collectstatic -l --no-input && \
     /app/env/bin/python manage.py compress && \
     rm -r /data/*
 


### PR DESCRIPTION
When using the current docker image, changing the language to German has almost no effect.
(ref: https://37c3.c3nav.de/ )

with this change the messages are compiled again in the buildstep.