### PR TITLE
Fix static path

### DIFF
--- a/src/c3nav/asgi.py
+++ b/src/c3nav/asgi.py
@@ -66,7 +66,7 @@ with suppress(ImportError):
         "http": Starlette(routes=[
             Mount(
                 path=settings.STATIC_URL,
-                app=StaticFiles(directory=settings.STATIC_ROOT, follow_symlink=True),
+                app=StaticFiles(directory=str(settings.STATIC_ROOT), follow_symlink=True),
                 name='static',
             ),
             Mount(path='/', app=django_asgi),


### PR DESCRIPTION
`StaticFiles` expects the `directory` to be a string, but `STATIC_ROOT` is a `Path` type when not set. 
Therefore no static files are served which breaks silently