### PR TITLE
Add staircase creation functionality

### DIFF
--- a/src/c3nav/editor/static/editor/js/editor.js
+++ b/src/c3nav/editor/static/editor/js/editor.js
@@ -182,6 +182,7 @@ editor = {
 
         $('#sidebar').addClass('loading').find('.content').html('');
         editor._cancel_editing();
+        editor._destroy_staircase_editing();
     },
     _fill_level_control: function (level_control, level_list, geometryURLs) {
         var levels = level_list.find('a');
@@ -496,6 +497,10 @@ editor = {
         // listener for form submits in the sidebar.
         e.preventDefault();
         if (editor._loading_geometry || $(this).is('.creation-lock') || $(this).is('.scan-lock')) return;
+        if (editor._staircase_layer) {
+            editor._staircase_submit($(this))
+            return
+        }
         var data = $(this).serialize();
         var btn = $(this).data('btn');
         if (btn !== undefined && btn !== null) {
@@ -1359,7 +1364,7 @@ editor = {
                 } else if (mapitem_type) {
                     // creating a new geometry, already drawn but form was rejected
                     options = editor._get_mapitem_type_style(mapitem_type);
-                    if (mapitem_type === 'area') {
+                    if (mapitem_type === 'area' || mapitem_type === 'staircase') {
                         options.fillOpacity = 0.5;
                     }
                 }
@@ -1379,7 +1384,7 @@ editor = {
             } else if (form.is('[data-new]')) {
                 // create new geometry
                 options = editor._get_mapitem_type_style(mapitem_type);
-                if (mapitem_type === 'area') {
+                if (mapitem_type === 'area' || mapitem_type === 'staircase') {
                     options.fillOpacity = 0.5;
                 }
                 form.addClass('creation-lock');
@@ -1427,6 +1432,10 @@ editor = {
                     form.prepend(selector);
                 }
                 startGeomEditing(selected_geomtype);
+            }
+
+            if (mapitem_type === 'staircase') {
+                editor._setup_staircase_editing()
             }
         }
     },
@@ -1651,6 +1660,170 @@ editor = {
         if (!editor._wifi_scan_waits && $('#sidebar').find('.scancollector.running').length) {
             editor._wifi_scan_waits = true;
             mobileclient.scanNow();
+        }
+    },
+    
+    // Staircase editing functionality
+
+    _setup_staircase_editing: function() {
+        editor._staircase_steps_count = 10
+        editor._staircase_layer = L.layerGroup().addTo(editor.map);
+        $('#stairway-steps').on('input', function() {
+            editor._staircase_steps_count = parseInt($(this).val()) || 10;
+            editor._update_staircase_preview();
+        });
+
+        editor.map.on('editable:editing', editor._update_staircase_preview);
+    },
+
+    _destroy_staircase_editing: function() {
+        if (editor._staircase_layer) {
+            editor.map.removeLayer(editor._staircase_layer)
+            editor._staircase_layer = null
+        }
+        editor.map.off('editable:editing', editor._update_staircase_preview)
+        if (editor._current_editing_shape && editor._current_editing_shape.editor) {
+            editor._current_editing_shape.editor.cancelDrawing()
+            editor._current_editing_shape.remove()
+            editor._current_editing_shape = null
+        }
+    },
+
+    _transform_point_for_staircase: function(p, p0, cos_a, sin_a) {
+        return {
+            x: + (p.x - p0.x) * cos_a + (p.y - p0.y) * sin_a + p0.x,
+            y: - (p.x - p0.x) * sin_a + (p.y - p0.y) * cos_a + p0.y,
+        }
+    },
+
+    _transform_for_staircase: function(xs, ys, num_stairs) {
+        let base_length = Math.sqrt((xs[1]-xs[0])**2 + (ys[1]-ys[0])**2)
+        let cos_a = (xs[1] - xs[0]) / base_length
+        let sin_a = (ys[1] - ys[0]) / base_length
+        let p0 = { x: xs[0], y: ys[0] }
+
+        xs = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).x)
+        ys = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).y)
+        n = xs.length
+
+        if (Math.abs(Math.max(...ys) - ys[0]) > Math.abs(Math.min(...ys) - ys[0])) {
+            height = Math.max(...ys) - ys[0]
+        } else {
+            height = Math.min(...ys) - ys[0]
+        }
+
+        // If the user aligns the staircase creation polygon to an edge of a Space (supposedly the
+        // Space representing the stairwell), we need to ensure that the stairs' lines overflow a
+        // bit, otherwise they won't get picked up by the map rendering algorithm (which may see a
+        // stair that doesn't split the Space into two parts and gets confused).
+        // Hence the -X_OVERFLOW and +X_OVERFLOW; X_OVERFLOW = '2 units' seemed reasonable.
+        const X_OVERFLOW = 2;
+        lines = [{p1: { x: xs[0]-X_OVERFLOW, y: ys[0] }, p2: { x: xs[1]+X_OVERFLOW, y: ys[1] }}]
+        for (i = 1; i < num_stairs; ++i) {
+            // intersect line y=y0+height/num_stairs*i with all transformed (xs,ys)
+            y = ys[0] + height/num_stairs*i
+            inters_xs = []
+            for (j = 0; j < n; ++j) {
+                y1 = ys[j]
+                y2 = ys[(j+1)%n]
+                x1 = xs[j]
+                x2 = xs[(j+1)%n]
+                if ((y1 > y && y2 > y) || (y1 < y && y2 < y)) {
+                    continue
+                }
+
+                if (Math.abs(x2 - x1) < 0.0001) {
+                    // vertical line, m would be infinity
+                    inters_xs.push(x1)
+                    continue
+                }
+
+                m = (y2 - y1) / (x2 - x1)
+                q = y2 - m * x2
+                inters_xs.push((y - q) / m)
+            }
+
+            if (inters_xs.length < 2) {
+                continue
+            }
+
+            min_xs = Math.min(...inters_xs)
+            max_xs = Math.max(...inters_xs)
+            lines.push({p1: {x: min_xs-X_OVERFLOW, y: y}, p2: {x: max_xs+X_OVERFLOW, y: y}})
+        }
+
+        lines = lines.map(l => ({
+            p1: editor._transform_point_for_staircase(l.p1, p0, cos_a, -sin_a),
+            p2: editor._transform_point_for_staircase(l.p2, p0, cos_a, -sin_a),
+        }))
+
+        return lines
+    },
+
+    _get_staircase_lines: function() {
+        if (!editor._current_editing_shape || !editor._current_editing_shape._parts) {
+            return []
+        }
+        points = editor._current_editing_shape._parts[0] || []
+        if (points.length < 3) {
+            return []
+        }
+
+        xs = points.map(p => p.x)
+        ys = points.map(p => p.y)
+        lines = editor._transform_for_staircase(xs, ys, editor._staircase_steps_count)
+        lines = lines.map(l => [
+            editor.map.layerPointToLatLng([l.p1.x, l.p1.y]),
+            editor.map.layerPointToLatLng([l.p2.x, l.p2.y]),
+        ])
+        return lines
+    },
+
+    _update_staircase_preview: function(e = null) {
+        if (editor._staircase_layer) {
+            editor._staircase_layer.clearLayers()
+        }
+        lines = editor._get_staircase_lines()
+        lines.forEach(l => {
+            L.polyline(l, {color: "red"}).addTo(editor._staircase_layer);
+        })
+    },
+
+    _staircase_submit: function(form) {
+        csrfmiddlewaretoken = form.find('input[name=csrfmiddlewaretoken]').attr('value')
+        import_tag = form.find('input[name=import_tag]').val()
+        space = form.attr('space')
+        lines = editor._get_staircase_lines()
+
+        save_stair = l => fetch("/editor/spaces/" + space + "/stairs/create", {
+            method: "POST",
+            headers: {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+            },
+            body: "csrfmiddlewaretoken=" + encodeURIComponent(csrfmiddlewaretoken) +
+                "&geometry=" + encodeURIComponent(JSON.stringify({
+                    type: "LineString",
+                    coordinates: [[l[0]["lng"], l[0]["lat"]], [l[1]["lng"], l[1]["lat"]]]
+                })) +
+                "&import_tag=" + encodeURIComponent(import_tag)
+        });
+
+        complete_redirect = () => {
+            form.remove()
+            window.location.href = "/editor/spaces/" + space + "/stairs"
+        }
+
+        if (lines.length === 0) {
+            complete_redirect()
+        } else {
+            let first = lines.shift()
+            // save one stair first, so a changeset is created if there is not already one
+            save_stair(first).then(() => {
+                // then save the remaining stairs all at once, ending up in the changeset
+                Promise.all(lines.map(save_stair))
+                    .then(complete_redirect)
+            })
         }
     }
 };

--- a/src/c3nav/editor/static/editor/js/editor.js
+++ b/src/c3nav/editor/static/editor/js/editor.js
@@ -498,8 +498,8 @@ editor = {
         e.preventDefault();
         if (editor._loading_geometry || $(this).is('.creation-lock') || $(this).is('.scan-lock')) return;
         if (editor._staircase_layer) {
-            editor._staircase_submit($(this))
-            return
+            editor._staircase_submit($(this));
+            return;
         }
         var data = $(this).serialize();
         var btn = $(this).data('btn');
@@ -1435,7 +1435,7 @@ editor = {
             }
 
             if (mapitem_type === 'staircase') {
-                editor._setup_staircase_editing()
+                editor._setup_staircase_editing();
             }
         }
     },
@@ -1666,7 +1666,7 @@ editor = {
     // Staircase editing functionality
 
     _setup_staircase_editing: function() {
-        editor._staircase_steps_count = 10
+        editor._staircase_steps_count = 10;
         editor._staircase_layer = L.layerGroup().addTo(editor.map);
         $('#stairway-steps').on('input', function() {
             editor._staircase_steps_count = parseInt($(this).val()) || 10;
@@ -1678,14 +1678,14 @@ editor = {
 
     _destroy_staircase_editing: function() {
         if (editor._staircase_layer) {
-            editor.map.removeLayer(editor._staircase_layer)
-            editor._staircase_layer = null
+            editor.map.removeLayer(editor._staircase_layer);
+            editor._staircase_layer = null;
         }
-        editor.map.off('editable:editing', editor._update_staircase_preview)
+        editor.map.off('editable:editing', editor._update_staircase_preview);
         if (editor._current_editing_shape && editor._current_editing_shape.editor) {
-            editor._current_editing_shape.editor.cancelDrawing()
-            editor._current_editing_shape.remove()
-            editor._current_editing_shape = null
+            editor._current_editing_shape.editor.cancelDrawing();
+            editor._current_editing_shape.remove();
+            editor._current_editing_shape = null;
         }
     },
 
@@ -1693,23 +1693,23 @@ editor = {
         return {
             x: + (p.x - p0.x) * cos_a + (p.y - p0.y) * sin_a + p0.x,
             y: - (p.x - p0.x) * sin_a + (p.y - p0.y) * cos_a + p0.y,
-        }
+        };
     },
 
     _transform_for_staircase: function(xs, ys, num_stairs) {
-        let base_length = Math.sqrt((xs[1]-xs[0])**2 + (ys[1]-ys[0])**2)
-        let cos_a = (xs[1] - xs[0]) / base_length
-        let sin_a = (ys[1] - ys[0]) / base_length
-        let p0 = { x: xs[0], y: ys[0] }
+        let base_length = Math.sqrt((xs[1]-xs[0])**2 + (ys[1]-ys[0])**2);
+        let cos_a = (xs[1] - xs[0]) / base_length;
+        let sin_a = (ys[1] - ys[0]) / base_length;
+        let p0 = { x: xs[0], y: ys[0] };
 
-        xs = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).x)
-        ys = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).y)
-        n = xs.length
+        xs = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).x);
+        ys = points.map(p => editor._transform_point_for_staircase(p, p0, cos_a, sin_a).y);
+        n = xs.length;
 
         if (Math.abs(Math.max(...ys) - ys[0]) > Math.abs(Math.min(...ys) - ys[0])) {
-            height = Math.max(...ys) - ys[0]
+            height = Math.max(...ys) - ys[0];
         } else {
-            height = Math.min(...ys) - ys[0]
+            height = Math.min(...ys) - ys[0];
         }
 
         // If the user aligns the staircase creation polygon to an edge of a Space (supposedly the
@@ -1718,82 +1718,82 @@ editor = {
         // stair that doesn't split the Space into two parts and gets confused).
         // Hence the -X_OVERFLOW and +X_OVERFLOW; X_OVERFLOW = '2 units' seemed reasonable.
         const X_OVERFLOW = 2;
-        lines = [{p1: { x: xs[0]-X_OVERFLOW, y: ys[0] }, p2: { x: xs[1]+X_OVERFLOW, y: ys[1] }}]
+        lines = [{p1: { x: xs[0]-X_OVERFLOW, y: ys[0] }, p2: { x: xs[1]+X_OVERFLOW, y: ys[1] }}];
         for (i = 1; i < num_stairs; ++i) {
             // intersect line y=y0+height/num_stairs*i with all transformed (xs,ys)
-            y = ys[0] + height/num_stairs*i
-            inters_xs = []
+            y = ys[0] + height/num_stairs*i;
+            inters_xs = [];
             for (j = 0; j < n; ++j) {
-                y1 = ys[j]
-                y2 = ys[(j+1)%n]
-                x1 = xs[j]
-                x2 = xs[(j+1)%n]
+                y1 = ys[j];
+                y2 = ys[(j+1)%n];
+                x1 = xs[j];
+                x2 = xs[(j+1)%n];
                 if ((y1 > y && y2 > y) || (y1 < y && y2 < y)) {
-                    continue
+                    continue;
                 }
 
                 if (Math.abs(x2 - x1) < 0.0001) {
                     // vertical line, m would be infinity
-                    inters_xs.push(x1)
-                    continue
+                    inters_xs.push(x1);
+                    continue;
                 }
 
-                m = (y2 - y1) / (x2 - x1)
-                q = y2 - m * x2
-                inters_xs.push((y - q) / m)
+                m = (y2 - y1) / (x2 - x1);
+                q = y2 - m * x2;
+                inters_xs.push((y - q) / m);
             }
 
             if (inters_xs.length < 2) {
-                continue
+                continue;
             }
 
-            min_xs = Math.min(...inters_xs)
-            max_xs = Math.max(...inters_xs)
-            lines.push({p1: {x: min_xs-X_OVERFLOW, y: y}, p2: {x: max_xs+X_OVERFLOW, y: y}})
+            min_xs = Math.min(...inters_xs);
+            max_xs = Math.max(...inters_xs);
+            lines.push({p1: {x: min_xs-X_OVERFLOW, y: y}, p2: {x: max_xs+X_OVERFLOW, y: y}});
         }
 
         lines = lines.map(l => ({
             p1: editor._transform_point_for_staircase(l.p1, p0, cos_a, -sin_a),
             p2: editor._transform_point_for_staircase(l.p2, p0, cos_a, -sin_a),
-        }))
+        }));
 
-        return lines
+        return lines;
     },
 
     _get_staircase_lines: function() {
         if (!editor._current_editing_shape || !editor._current_editing_shape._parts) {
-            return []
+            return [];
         }
-        points = editor._current_editing_shape._parts[0] || []
+        points = editor._current_editing_shape._parts[0] || [];
         if (points.length < 3) {
-            return []
+            return [];
         }
 
-        xs = points.map(p => p.x)
-        ys = points.map(p => p.y)
-        lines = editor._transform_for_staircase(xs, ys, editor._staircase_steps_count)
+        xs = points.map(p => p.x);
+        ys = points.map(p => p.y);
+        lines = editor._transform_for_staircase(xs, ys, editor._staircase_steps_count);
         lines = lines.map(l => [
             editor.map.layerPointToLatLng([l.p1.x, l.p1.y]),
             editor.map.layerPointToLatLng([l.p2.x, l.p2.y]),
-        ])
-        return lines
+        ]);
+        return lines;
     },
 
     _update_staircase_preview: function(e = null) {
         if (editor._staircase_layer) {
-            editor._staircase_layer.clearLayers()
+            editor._staircase_layer.clearLayers();
         }
-        lines = editor._get_staircase_lines()
+        lines = editor._get_staircase_lines();
         lines.forEach(l => {
             L.polyline(l, {color: "red"}).addTo(editor._staircase_layer);
-        })
+        });
     },
 
     _staircase_submit: function(form) {
-        csrfmiddlewaretoken = form.find('input[name=csrfmiddlewaretoken]').attr('value')
-        import_tag = form.find('input[name=import_tag]').val()
-        space = form.attr('space')
-        lines = editor._get_staircase_lines()
+        csrfmiddlewaretoken = form.find('input[name=csrfmiddlewaretoken]').attr('value');
+        import_tag = form.find('input[name=import_tag]').val();
+        space = form.attr('space');
+        lines = editor._get_staircase_lines();
 
         save_stair = l => fetch("/editor/spaces/" + space + "/stairs/create", {
             method: "POST",
@@ -1806,24 +1806,24 @@ editor = {
                     type: "LineString",
                     coordinates: [[l[0]["lng"], l[0]["lat"]], [l[1]["lng"], l[1]["lat"]]]
                 })) +
-                "&import_tag=" + encodeURIComponent(import_tag)
+                "&import_tag=" + encodeURIComponent(import_tag),
         });
 
         complete_redirect = () => {
-            form.remove()
-            window.location.href = "/editor/spaces/" + space + "/stairs"
-        }
+            form.remove();
+            window.location.href = "/editor/spaces/" + space + "/stairs";
+        };
 
         if (lines.length === 0) {
-            complete_redirect()
+            complete_redirect();
         } else {
-            let first = lines.shift()
+            let first = lines.shift();
             // save one stair first, so a changeset is created if there is not already one
             save_stair(first).then(() => {
                 // then save the remaining stairs all at once, ending up in the changeset
                 Promise.all(lines.map(save_stair))
-                    .then(complete_redirect)
-            })
+                    .then(complete_redirect);
+            });
         }
     }
 };

--- a/src/c3nav/editor/static/editor/js/editor.js
+++ b/src/c3nav/editor/static/editor/js/editor.js
@@ -1662,7 +1662,7 @@ editor = {
             mobileclient.scanNow();
         }
     },
-    
+
     // Staircase editing functionality
 
     _setup_staircase_editing: function() {

--- a/src/c3nav/editor/templates/editor/create_staircase.html
+++ b/src/c3nav/editor/templates/editor/create_staircase.html
@@ -1,0 +1,34 @@
+{% load bootstrap3 %}
+{% load i18n %}
+
+{% include 'editor/fragment_levels.html' %}
+
+<h3>
+    {% blocktrans %}Add staircase{% endblocktrans %}
+</h3>
+{% bootstrap_messages %}
+
+<form space="{{ space }}" {% if nozoom %}data-nozoom {% endif %}data-onbeforeunload data-new="staircase" data-geomtype="polygon" {% if access_restriction_select %} data-access-restriction-select{% endif %}>
+    {% csrf_token %}
+    {% bootstrap_form form %}
+    <div class="form-group">
+        <label for="stairway-steps">{% trans 'Number of steps:' %}</label>
+        <input type="number" id="stairway-steps" class="form-control" value="10">
+    </div>
+    {% buttons %}
+    {% if can_edit %}
+        {% if not nosave %}
+            <button type="submit" accesskey="m" class="btn btn-primary pull-right">
+                {% trans 'Save' %}
+            </button>
+        {% endif %}
+    {% endif %}
+    <a class="btn btn-danger cancel-btn" href="{{ back_url }}">
+        {% if can_edit %}
+            {% trans 'Cancel' %}
+        {% else %}
+            {% trans 'Back' %}
+        {% endif %}
+    </a>
+    {% endbuttons %}
+</form>

--- a/src/c3nav/editor/templates/editor/list.html
+++ b/src/c3nav/editor/templates/editor/list.html
@@ -20,6 +20,11 @@
     <a class="btn btn-default btn-xs" accesskey="n" href="{{ create_url }}">
         <i class="glyphicon glyphicon-plus"></i> {% blocktrans %}New {{ model_title }}{% endblocktrans %}
     </a>
+    {% if model_title == "Stair" %}
+        <a class="btn btn-default btn-xs" accesskey="n" href="/editor/spaces/{{ space.id }}/staircase">
+            <i class="glyphicon glyphicon-plus"></i> {% blocktrans %}New staircase{% endblocktrans %}
+        </a>
+    {% endif %}
 {% endif %}
 
 {% if explicit_edit %}

--- a/src/c3nav/editor/urls.py
+++ b/src/c3nav/editor/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     path('levels/<int:level>/overlays/<int:pk>/', overlay_features, name='editor.levels.overlay'),
     path('levels/<int:level>/overlays/<int:overlay>/create', overlay_feature_edit, name='editor.levels.overlay.create'),
     path('levels/<int:level>/overlays/<int:overlay>/features/<int:pk>', overlay_feature_edit, name='editor.levels.overlay.edit'),
+    path('spaces/<int:space>/staircase', edit, name='editor.stairs.staircase', kwargs={'model': apps.get_model('mapdata', 'Stair')}),
     path('overlayfeatures/<int:pk>', overlay_feature_edit, name='editor.overlayfeatures.edit'),
     path('changeset/', changeset_redirect, name='editor.changesets.current'),
     path('changesets/<int:pk>/', changeset_detail, name='editor.changesets.detail'),

--- a/src/c3nav/editor/views/edit.py
+++ b/src/c3nav/editor/views/edit.py
@@ -405,7 +405,11 @@ def edit(request, pk=None, model=None, level=None, space=None, on_top_of=None, e
             "access_restriction_select": True,
         })
 
-    return render(request, 'editor/edit.html', ctx)
+    if request.path.endswith("staircase"):
+        ctx["space"] = space_id
+        return render(request, 'editor/create_staircase.html', ctx)
+    else:
+        return render(request, 'editor/edit.html', ctx)
 
 
 def get_visible_spaces(request):


### PR DESCRIPTION
This PR adds a button to the Stairs page that allows adding multiple parallel stairs at once (i.e. a staircase):

![output](https://github.com/user-attachments/assets/e7a2c388-8094-42c5-a617-75098d6e167a)

Even strange staircase shapes are supported (the stairs are created all parallel to the first edge in the polygon):

<img width="290" height="193" alt="image" src="https://github.com/user-attachments/assets/46239812-4d62-4b01-a6f1-41d8506eab8f" />

I am not completely sure about some of the changes I made, and I am happy to improve on them if I receive feedback:
- When saving N stairs, N requests are made to the server using the existing `/editor/spaces/{SPACE}/stairs/create` endpoint.
- When I first implemented this feature, when sending N requests all at once, most of them would get lost without giving any error, apparently due to the fact that they all created different changesets concurrently which then disappeared. Now I made it so that a request for a single stair is sent first, so that a changeset is instantiated, and then all other N-1 stair creation requests are sent, which end up in the correct changeset. Is it expected that there are such concurrency issues?
- I added a new HTML template for the staircase editing page. Since that page needed mostly the same runtime checks and template variables as the stair editing page (i.e. `editor/edit.html` rendered by `edit()` with `model=apps.get_model('mapdata', 'Stair')`), I added a special case in `edit()` that renders a different HTML page if the staircase endpoint is provided.

Let me know your thoughts.

<sub>Note: this code was initially written during <a href="https://noi.bz.it/en/events/hackathon-summer-edition/72816f01-a2f5-4981-99a8-421b1003e6df">a Hackathon</a> together with @dennisorlando @Degra02 @Usioumeo. The hackathon was organized by NOI, which also hosts SFScon, which uses c3nav for navigation during the conference.</sub>