### PR TITLE
fix runtime issues from c3nav setup

### DIFF
--- a/src/c3nav/mapdata/utils/cache/indexed.py
+++ b/src/c3nav/mapdata/utils/cache/indexed.py
@@ -65,8 +65,9 @@ class GeometryIndexed:
         cls._read_metadata(f, kwargs)
 
         # noinspection PyTypeChecker
+        # copy, because frombuffer on an immutable bytes object yields a read-only array
         kwargs['data'] = np.frombuffer(f.read(width * height * cls.dtype().itemsize), cls.dtype).reshape(
-            (height, width))
+            (height, width)).copy()
         return cls(**kwargs)
 
     @classmethod

--- a/src/c3nav/mapdata/utils/geometry.py
+++ b/src/c3nav/mapdata/utils/geometry.py
@@ -396,7 +396,7 @@ def get_line_of_sight(point: Point, polygon: Polygon | MultiPolygon, plot=False)
                 )).intersection(polygon))
                 if coord in segment.coords
             ))
-        except StopIteration, AttributeError:
+        except (StopIteration, AttributeError):
             coords.append((coord, None))
         else:
             ray_end_coord = next(iter(c for c in ray.coords if c != coord))

--- a/src/c3nav/site/static/site/js/c3nav.js
+++ b/src/c3nav/site/static/site/js/c3nav.js
@@ -744,23 +744,28 @@ c3nav = {
 
         // add origin and destination lines
         c3nav._location_point_overrides = {};
-        if (!c3nav._add_location_point_override(result.origin, result.items[0])) {
-            c3nav._add_line_to_route(first_primary_level, c3nav._add_intermediate_point(
-                result.origin.point.slice(1),
-                result.items[0].coordinates.slice(0, 2),
-                result.items[1].coordinates.slice(0, 2)
-            ), true);
-        }
-        if (!c3nav._add_location_point_override(result.destination, result.items.slice(-1)[0])) {
-            c3nav._add_line_to_route(last_primary_level, c3nav._add_intermediate_point(
-                result.destination.point.slice(1),
-                result.items[result.items.length - 1].coordinates.slice(0, 2),
-                result.items[result.items.length - 2].coordinates.slice(0, 2)
-            ).reverse(), true);
+        if (result.items.length > 0) {
+            if (!c3nav._add_location_point_override(result.origin, result.items[0])) {
+                c3nav._add_line_to_route(first_primary_level, c3nav._add_intermediate_point(
+                    result.origin.point.slice(1),
+                    result.items[0].coordinates.slice(0, 2),
+                    result.items.length > 1 ? result.items[1].coordinates.slice(0, 2) : result.destination.point.slice(1)
+                ), true);
+            }
+            if (!c3nav._add_location_point_override(result.destination, result.items.slice(-1)[0])) {
+                c3nav._add_line_to_route(last_primary_level, c3nav._add_intermediate_point(
+                    result.destination.point.slice(1),
+                    result.items[result.items.length - 1].coordinates.slice(0, 2),
+                    result.items.length > 1 ? result.items[result.items.length - 2].coordinates.slice(0, 2) : result.origin.point.slice(1)
+                ).reverse(), true);
+            }
+        } else {
+            // direct line if no items
+            c3nav._add_line_to_route(result.origin.point[0], [result.origin.point.slice(1), result.destination.point.slice(1)], true);
         }
         c3nav.update_map_locations();
 
-        c3nav._firstRouteLevel = first_primary_level;
+        c3nav._firstRouteLevel = first_primary_level || result.origin.point[0];
         $route.find('span').text(result.summary);
         $route.find('em').text(result.options_summary);
         $route.removeClass('loading');


### PR DESCRIPTION
Hi,
I did run into bugs when setting up c3nav.

* editing a read-only buffer fails in some occasions when editing
* with only direct graph nodes between points, errors are raised when creating a route without intermediate points. (`TypeError: can't access property "coordinates", result.items[1] is undefined`)
* exception handling on `AttributeError` did fail