### PR TITLE
Remove deprecated shapely.speedups

### DIFF
--- a/src/c3nav/mapdata/utils/index.py
+++ b/src/c3nav/mapdata/utils/index.py
@@ -2,10 +2,7 @@ import operator
 from functools import reduce
 
 from django.core import checks
-from shapely import speedups
 
-if speedups.available:
-    speedups.enable()
 
 
 try:


### PR DESCRIPTION
Shapely is pinned to a version >=2 so it is fine to remove these lines enabling shapely speedups.

Fixes the shapely complaining about:

`FutureWarning: This function has no longer any effect, and will be removed in a future release. Starting with Shapely 2.0, equivalent speedups are always available`