### PR TITLE
Fix C3NAV_DATABASE_CONN_MAX_AGE environment variable

### DIFF
--- a/src/c3nav/asgi.py
+++ b/src/c3nav/asgi.py
@@ -7,7 +7,7 @@ from channels.security.websocket import OriginValidator
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "c3nav.settings")
-os.environ.setdefault("C3NAV_CONN_MAX_AGE", "0")
+os.environ.setdefault("C3NAV_DATABASE_CONN_MAX_AGE", "0")
 django_asgi = get_asgi_application()
 
 from c3nav.control.middleware import UserPermissionsChannelMiddleware  # noqa


### PR DESCRIPTION
This sets the default correctly to 0 to disable keeping connections open for the asgi server per default.

The Django env variables must include the section to work.
Therefore, it should be `C3NAV_DATABASE_CONN_MAX_AGE` as a default.

I also did run into issues with this as otherwise connections are kept open for 120 seconds if not using sqlite.

Maybe this also solve the random hangs mentioned in: https://github.com/c3nav/c3nav/pull/265#issuecomment-2954312087

Might also need to be added to celery..?